### PR TITLE
Upgrade tool versions, fixes line break

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude:
 repos:
   - repo: https://github.com/executablebooks/mdformat
     # Do this before other tools "fixing" the line endings
-    rev: 0.7.17
+    rev: 0.7.22
     hooks:
       - id: mdformat
         name: Format Markdown
@@ -20,7 +20,7 @@ repos:
           - setuptools
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       # - id: no-commit-to-branch
       #  args: [--branch, main]
@@ -46,7 +46,7 @@ repos:
         additional_dependencies:
           - setuptools
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
   - repo: https://github.com/shellcheck-py/shellcheck-py

--- a/README.md
+++ b/README.md
@@ -8,44 +8,39 @@ Display HA dashboards in kiosk mode directly on your HAOS server
 
 Launches X-Windows on local HAOS server followed by OpenBox window manager
 and Luakit browser.\
-Standard mouse and keyboard interactions should work
-automatically.
+Standard mouse and keyboard interactions should work automatically.
 
 **NOTE:** You must enter your HA username and password in the
 *Configuration* tab for add-on to start.
 
 Note that the Luakit is launched in kiosk-like (*passthrough*) mode.\
-To
-enter *normal* mode (similar to command mode in `vi`), press
+To enter *normal* mode (similar to command mode in `vi`), press
 `ctl-alt-esc`\
-You can then return to *passthrough* mode by pressing
-`ctl-Z` or enter *insert* mode by pressing `i`\
-See luakit documentation
-for available commands.\
-In general, you want to stay in `passthrough`
-mode.
+You can then return to *passthrough* mode by pressing `ctl-Z` or enter
+*insert* mode by pressing `i`\
+See luakit documentation for available commands.\
+In general, you want to stay in `passthrough` mode.
 
 ## Configuration Options
 
-### HA Username \[required\]
+### HA Username [required]
 
 Enter your Home Assistant login name
 
-### HA Password \[required\]
+### HA Password [required]
 
 Enter your Home Assistant password
 
 ### HA URL
 
 Default is: `http://localhost:8123`\
-In general, you shouldn't need to
-change this since this is running on the local server.
+In general, you shouldn't need to change this since this is running on the
+local server.
 
 ### HA Dashboard
 
 Name of starting dashboard.\
-Defaults to "" which loads the default
-`Lovelace` dashboard.
+Defaults to "" which loads the default `Lovelace` dashboard.
 
 ### Login Delay
 
@@ -55,8 +50,7 @@ Defaults to `1` second.
 ### HDMI Port
 
 HDMI output port. Technically can be `0` or `1` (Defaults to `0`).\
-BUT
-currently has no effect on stock HAOS on RPi since configured to mirror
+BUT currently has no effect on stock HAOS on RPi since configured to mirror
 HDMI0 onto HDMI1.
 
 ### Screen Timeout
@@ -68,9 +62,8 @@ Default is `600` seconds.
 ### Browser Refresh
 
 Time between browser refreshes. Set to `0` to disable.\
-Recommended
-becauseon default RPi config, console errors *may* overwrite the
-dashboard.\
+Recommended becauseon default RPi config, console errors *may* overwrite
+the dashboard.\
 Default is `600` seconds.
 
 ### Zoom Level

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HAOS-kiosk
 
-Display HA dashboards in kiosk mode directly on your HAOS server
+Display HA dashboards in kiosk mode directly on your HAOS server.
 
 ## Author: Jeff Kosowsky
 
@@ -15,9 +15,9 @@ Standard mouse and keyboard interactions should work automatically.
 
 Note that the Luakit is launched in kiosk-like (*passthrough*) mode.\
 To enter *normal* mode (similar to command mode in `vi`), press
-`ctl-alt-esc`\
+`ctl-alt-esc`.\
 You can then return to *passthrough* mode by pressing `ctl-Z` or enter
-*insert* mode by pressing `i`\
+*insert* mode by pressing `i`.\
 See luakit documentation for available commands.\
 In general, you want to stay in `passthrough` mode.
 
@@ -25,11 +25,11 @@ In general, you want to stay in `passthrough` mode.
 
 ### HA Username [required]
 
-Enter your Home Assistant login name
+Enter your Home Assistant login name.
 
 ### HA Password [required]
 
-Enter your Home Assistant password
+Enter your Home Assistant password.
 
 ### HA URL
 
@@ -62,11 +62,11 @@ Default is `600` seconds.
 ### Browser Refresh
 
 Time between browser refreshes. Set to `0` to disable.\
-Recommended becauseon default RPi config, console errors *may* overwrite
-the dashboard.\
+Recommended because with the default RPi config, console errors *may*
+overwrite the dashboard.\
 Default is `600` seconds.
 
 ### Zoom Level
 
-Level of zoom with `100` being 100%. \
+Level of zoom with `100` being 100%.\
 Default is `100`.


### PR DESCRIPTION
Fixing the line break issue with mdformat just required to refer to a later version in the hook.  So I updated all the hooks.

I also fixed some punctuations and wording for "becauseon".