### PR TITLE
Improve dark mode - enable dark mode at browser level

### DIFF
--- a/haoskiosk/userconf.lua
+++ b/haoskiosk/userconf.lua
@@ -64,6 +64,11 @@ if theme == nil then
     theme = ''
 end
 
+if string.find(theme, '"dark":true') then
+    -- force luakit to be in dark mode
+    settings.application.prefer_dark_mode = true
+end
+
 local raw_sidebar = os.getenv("HA_SIDEBAR") or defaults.HA_SIDEBAR -- Valid entries: full (or ""), narrow, none,
 local valid_sidebars = { full = '', none = '"always_hidden"', narrow = '"auto"', [""] = '' }
 local sidebar = valid_sidebars[raw_sidebar]


### PR DESCRIPTION
I've improved the dark mode implementation to enable dark mode at the browser level. This will also already show the login screen and all other dialogs in bark mode (Similar like all the other browsers behave if switching between dark and light mode in the browser).