### PR TITLE
Add regional settings (locale) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ Options include: (Default: None)
 - Narrow (icons only)
 - None (hidden)
 
+### Regional Settings (locale)
+
+Allows to change the default regional settings (locale) in the browser. \
+Changing e.g. to de_DE.UTF-8 is changing the default language of luakit to German. 
+
+Default: en_US.UTF-8
+
 ### DEBUG
 
 For debugging purposes, launches `Xorg` and `openbox` and then sleeps

--- a/haoskiosk/README.md
+++ b/haoskiosk/README.md
@@ -93,6 +93,13 @@ Options include: (Default: None)
 - Narrow (icons only)
 - None (hidden)
 
+### Regional Settings (locale)
+
+Allows to change the default regional settings (locale) in the browser. \
+Changing e.g. to de_DE.UTF-8 is changing the default language of luakit to German. 
+
+Default: en_US.UTF-8
+
 ### DEBUG
 
 For debugging purposes, launches `Xorg` and `openbox` and then sleeps

--- a/haoskiosk/config.yaml
+++ b/haoskiosk/config.yaml
@@ -35,6 +35,7 @@ options:
   hdmi_port: 0
   ha_theme: "dark"
   ha_sidebar: "none"
+  locale: "en_US.UTF-8"
   debug_mode: false
 
 schema:
@@ -49,6 +50,7 @@ schema:
   hdmi_port: int(0,1)
   ha_theme: list(auto|dark|light|none)
   ha_sidebar: list(full|narrow|none)
+  locale: str
   debug_mode: bool
 
 translations:

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -23,6 +23,7 @@ trap '[ -n "$(jobs -p)" ] && kill $(jobs -p); [ -n "$TTY0_DELETED" ] && mknod -m
 #         BROWSER_REFRESH
 #         SCREEN_TIMEOUT
 #         HDMI_PORT
+#         LOCALE
 #         DEBUG_MODE
 #     - Hack to delete (and later restore) /dev/tty0 (needed for X to start)
 #     - Start X window system
@@ -72,6 +73,7 @@ get_config HDMI_PORT 0 # Default to 0
 #NOTE: For now, both HDMI ports are mirrored and there is only /dev/fb0
 #      Not sure how to get them unmirrored so that console can be on /dev/fb0 and X on /dev/fb1
 #      As a result, setting HDMI=0 vs. 1 has no effect
+get_config LOCALE
 get_config DEBUG_MODE false
 
 #Validate environment variables set by config.yaml
@@ -171,6 +173,9 @@ fi
         sleep 1
     done
 )&
+
+# setup locale to force the browser to use the correct language
+export LANG=$LOCALE
 
 echo "DEBUG_MODE=$DEBUG_MODE" #JJKCRAP
 if [ "$DEBUG_MODE" != true ]; then

--- a/haoskiosk/translations/en.yaml
+++ b/haoskiosk/translations/en.yaml
@@ -49,6 +49,11 @@ configuration:
       full: "Full"
       narrow: "Narrow"
       none: "None"
+  locale:
+    name: "Regional Settings (locale)"
+    description: |
+      Allows to define alternative regional settings. Changing e.g. to "de_DE.UTF-8" is 
+      changing the default language of luakit to German. [Default: en_US.UTF-8]
   debug_mode:
     name: "Debug Mode"
     description: |


### PR DESCRIPTION
I've added an option to overwrite the default `en_US.UTF-8` local setting. This is changing the default language to the regional settings defined in the option. E.g., changing to `de_DE.UFT-8` is changing the browser language to German and hence also changing the entire Home Assistant Web UI automatically to this language profile. If the specified HA user has not yet been logged in, the default language will automatically set to the regional settings. 