### PR TITLE
Add option to timeout mouse pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Time before screen blanks in seconds. Set to `0` to never timeout.
 
 Default: 0 seconds (never timeout)
 
+### Mouse Pointer Timeout
+
+Time in seconds until the mouse pointer is hidden. Mouse pointer disapiers \
+after the the specified time if user does not move the mouse. Set to `0` to never timeout.
+
+Default: 30 seconds
+
 ### Output Number
 
 Choose which of the *connected* video output ports to use. Set to 1 to use

--- a/haoskiosk/Dockerfile
+++ b/haoskiosk/Dockerfile
@@ -32,6 +32,7 @@ RUN apk update && apk add --no-cache \
     xset \
     setxkbmap \
     bash \
+    unclutter-xfixes \
     && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.21/community luakit=2.3.6-r0 \
     && rm -rf /var/cache/apk/*
 

--- a/haoskiosk/README.md
+++ b/haoskiosk/README.md
@@ -71,6 +71,13 @@ Time before screen blanks in seconds. Set to `0` to never timeout.
 
 Default: 0 seconds (never timeout)
 
+### Mouse Pointer Timeout
+
+Time in seconds until the mouse pointer is hidden. Mouse pointer disapiers \
+after the the specified time if user does not move the mouse. Set to `0` to never timeout.
+
+Default: 30 seconds
+
 ### Output Number
 
 Choose which of the *connected* video output ports to use. Set to 1 to use

--- a/haoskiosk/config.yaml
+++ b/haoskiosk/config.yaml
@@ -60,6 +60,7 @@ options:
   zoom_level: 100
   browser_refresh: 600
   screen_timeout: 0
+  mouse_pointer_timeout: 30
   output_number: 1
   ha_theme: "dark"
   ha_sidebar: "none"
@@ -79,6 +80,7 @@ schema:
   zoom_level: int(10,1000)
   browser_refresh: int(0,)
   screen_timeout: int(0,)
+  mouse_pointer_timeout: int(0,)
   output_number: int(1,2)
   ha_theme: list(auto|dark|light|none)
   ha_sidebar: list(full|narrow|none)

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -35,6 +35,7 @@ trap cleanup INT TERM EXIT
 #         XORG_CONF
 #         XORG_APPEND_REPLACE
 #         DEBUG_MODE
+#         MOUSE_POINTER_TIMEOUT
 #
 #     - Hack to delete (and later restore) /dev/tty0 (needed for X to start
 #       and to prevent udev permission errors))
@@ -107,6 +108,7 @@ load_config_var KEYBOARD_LAYOUT us
 load_config_var XORG_CONF
 load_config_var XORG_APPEND_REPLACE append
 load_config_var DEBUG_MODE false
+load_config_var MOUSE_POINTER_TIMEOUT 30 # Default to 30 seconds
 
 # Validate environment variables set by config.yaml
 if [ -z "$HA_USERNAME" ] || [ -z "$HA_PASSWORD" ]; then
@@ -215,6 +217,11 @@ bashio::log.info "X server started successfully after $i seconds..."
 
 #Stop console blinking cursor (this projects through the X-screen)
 echo -e "\033[?25l" > /dev/console
+
+# hide mouse pointer
+if [ "$MOUSE_POINTER_TIMEOUT" -ne 0 ]; then
+    unclutter-xfixes --start-hidden --hide-on-touch --timeout $MOUSE_POINTER_TIMEOUT  &
+fi
 
 ### Start Openbox in the background
 openbox &

--- a/haoskiosk/translations/en.yaml
+++ b/haoskiosk/translations/en.yaml
@@ -31,6 +31,11 @@ configuration:
   screen_timeout:
     name: "Screen Timeout"
     description: "Time in seconds until screen blanks; 0 for never [Default: 0]"
+  mouse_pointer_timeout:
+    name: "Mouse Pointer Timeout"
+    description: |
+      Time in seconds until the mouse pointer is hidden. Mouse pointer disapiers
+      after the the specified time if user does not move the mouse. Set to `0` to never timeout. (Default: 30)
   output_number:
     name: "Output Number"
     description: |


### PR DESCRIPTION
I've added an option to be able to let the  mouse pointer time out after defined seconds of idle. This is especially helpful for touch screens as you don't want to see the mouse pointer on touch screens. This has been already discussed in PR https://github.com/puterboy/HAOS-kiosk/pull/24