### PR TITLE
using the keyboard layout settings to setup regional settings (locale)

### DIFF
--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -295,6 +295,7 @@ fi
 setxkbmap "$KEYBOARD_LAYOUT"
 bashio::log.info "Setting Keyboard Layout: $KEYBOARD_LAYOUT"
 setxkbmap -query #Log layout
+export LANG=$KEYBOARD_LAYOUT
 
 # Poll to send <Control-r> when screen unblanks to force reload of luakit page
 (


### PR DESCRIPTION
Since the testing branch already included keyboard language support, I just extended this support to also change the locale (regional settings) to change the browser language to the same.

(This has been discussed in PR https://github.com/puterboy/HAOS-kiosk/pull/26)