### PR TITLE
libinput reload all ID_INPUT devices that generate events

### DIFF
--- a/haoskiosk/tag-input-devices.sh
+++ b/haoskiosk/tag-input-devices.sh
@@ -26,6 +26,7 @@ for dev in /dev/input/event*; do
     echo "$udevadm_info"
     devpath=$(echo "$udevadm_info" | grep -m1 DEVPATH | cut -d= -f2)
     if [[ ! $devpath =~ /usb[0-9]+.*[0-9]{4}:[0-9A-Fa-f]{4}:[0-9A-Fa-f]{4} ]]; then
+        : '
         #Get Devtype
         dev_type=$(echo "$udevadm_info" | grep -m1 ID_INPUT_ | cut -d= -f1)
         echo "$dev_type"
@@ -36,6 +37,7 @@ for dev in /dev/input/event*; do
             echo "$device_type=1"
             echo "LIBINPUT_DEVICE_GROUP=input"
         } > "/run/udev/data/+input:input$input_num"
+        '
         
         # Trigger udev to process existing tags
         udevadm test "$devpath" >/dev/null 2>&1

--- a/haoskiosk/tag-input-devices.sh
+++ b/haoskiosk/tag-input-devices.sh
@@ -23,12 +23,12 @@ for dev in /dev/input/event*; do
 
     # Get device path to check if USB
     udevadm_info=$(udevadm info "$dev")
-    echo $udevadm_info
-    devpath=$(echo $udevadm_info | grep -m1 DEVPATH | cut -d= -f2)
+    echo "$udevadm_info"
+    devpath=$(echo "$udevadm_info" | grep -m1 DEVPATH | cut -d= -f2)
     if [[ ! $devpath =~ /usb[0-9]+.*[0-9]{4}:[0-9A-Fa-f]{4}:[0-9A-Fa-f]{4} ]]; then
         #Get Devtype
-        dev_type=$(echo $udevadm_info | grep -m1 ID_INPUT_ | cut -d= -f1)
-        echo $dev_type
+        dev_type=$(echo "$udevadm_info" | grep -m1 ID_INPUT_ | cut -d= -f1)
+        echo "$dev_type"
         
         # Write tags to udev data
         {

--- a/haoskiosk/tag-input-devices.sh
+++ b/haoskiosk/tag-input-devices.sh
@@ -29,6 +29,7 @@ for dev in /dev/input/event*; do
         #Get Devtype
         dev_type=$(echo $udevadm_info | grep -m1 ID_INPUT_ | cut -d= -f1)
         echo $dev_type
+        : '
         # Write tags to udev data
         {
             echo "ID_INPUT=1"
@@ -38,7 +39,7 @@ for dev in /dev/input/event*; do
         
         # Trigger udev to process existing tags
         udevadm test "$devpath" >/dev/null 2>&1
-
+        '
         echo "$devname: Skipped (non-USB)"
         continue
     fi

--- a/haoskiosk/tag-input-devices.sh
+++ b/haoskiosk/tag-input-devices.sh
@@ -23,10 +23,11 @@ for dev in /dev/input/event*; do
 
     # Get device path to check if USB
     udevadm_info=$(udevadm info "$dev")
-    devpath=$(echo "$udevadm_info" | grep -m1 DEVPATH | cut -d= -f2)
+    echo $udevadm_info
+    devpath=$(echo $udevadm_info | grep -m1 DEVPATH | cut -d= -f2)
     if [[ ! $devpath =~ /usb[0-9]+.*[0-9]{4}:[0-9A-Fa-f]{4}:[0-9A-Fa-f]{4} ]]; then
         #Get Devtype
-        dev_type=$(echo "$udevadm_info" | grep -m1 ID_INPUT_ | cut -d= -f1)
+        dev_type=$(echo $udevadm_info | grep -m1 ID_INPUT_ | cut -d= -f1)
         echo $dev_type
         # Write tags to udev data
         {

--- a/haoskiosk/tag-input-devices.sh
+++ b/haoskiosk/tag-input-devices.sh
@@ -24,6 +24,7 @@ for dev in /dev/input/event*; do
     # Get device path to check if USB
     devpath=$(udevadm info "$dev" | grep -m1 DEVPATH | cut -d= -f2)
     if [[ ! $devpath =~ /usb[0-9]+.*[0-9]{4}:[0-9A-Fa-f]{4}:[0-9A-Fa-f]{4} ]]; then
+        echo $dev 
         # Trigger udev to process existing tags
         udevadm test "$devpath" >/dev/null 2>&1
 

--- a/haoskiosk/tag-input-devices.sh
+++ b/haoskiosk/tag-input-devices.sh
@@ -22,10 +22,13 @@ for dev in /dev/input/event*; do
     input_num=${devname#event}
 
     # Get device path to check if USB
-    udevadm_info=$(udevadm info "$dev")
-    devpath=$(echo $udevadm_info | grep -m1 DEVPATH | cut -d= -f2)
+    devpath=$((udevadm info "$dev" | grep -m1 DEVPATH | cut -d= -f2)
     if [[ ! $devpath =~ /usb[0-9]+.*[0-9]{4}:[0-9A-Fa-f]{4}:[0-9A-Fa-f]{4} ]]; then
-        echo $udevadm_info
+        # Write tags to udev data
+        {
+            echo "ID_INPUT=1"
+        } > "/run/udev/data/+input:input$input_num"
+        
         # Trigger udev to process existing tags
         udevadm test "$devpath" >/dev/null 2>&1
 

--- a/haoskiosk/tag-input-devices.sh
+++ b/haoskiosk/tag-input-devices.sh
@@ -22,27 +22,12 @@ for dev in /dev/input/event*; do
     input_num=${devname#event}
 
     # Get device path to check if USB
-    udevadm_info=$(udevadm info "$dev")
-    echo "$udevadm_info"
-    devpath=$(echo "$udevadm_info" | grep -m1 DEVPATH | cut -d= -f2)
+    devpath=$(udevadm info "$dev" | grep -m1 DEVPATH | cut -d= -f2)
     if [[ ! $devpath =~ /usb[0-9]+.*[0-9]{4}:[0-9A-Fa-f]{4}:[0-9A-Fa-f]{4} ]]; then
-        : '
-        #Get Devtype
-        dev_type=$(echo "$udevadm_info" | grep -m1 ID_INPUT_ | cut -d= -f1)
-        echo "$dev_type"
-        
-        # Write tags to udev data
-        {
-            echo "ID_INPUT=1"
-            echo "$device_type=1"
-            echo "LIBINPUT_DEVICE_GROUP=input"
-        } > "/run/udev/data/+input:input$input_num"
-        '
-        
-        # Trigger udev to process existing tags
+        # Trigger a reload of all properties according to existing tags
         udevadm test "$devpath" >/dev/null 2>&1
         
-        echo "$devname: Skipped (non-USB)"
+        echo "$devname: Reloaded (non-USB)"
         continue
     fi
 

--- a/haoskiosk/tag-input-devices.sh
+++ b/haoskiosk/tag-input-devices.sh
@@ -29,7 +29,7 @@ for dev in /dev/input/event*; do
         #Get Devtype
         dev_type=$(echo $udevadm_info | grep -m1 ID_INPUT_ | cut -d= -f1)
         echo $dev_type
-        : '
+        
         # Write tags to udev data
         {
             echo "ID_INPUT=1"
@@ -39,7 +39,7 @@ for dev in /dev/input/event*; do
         
         # Trigger udev to process existing tags
         udevadm test "$devpath" >/dev/null 2>&1
-        '
+        
         echo "$devname: Skipped (non-USB)"
         continue
     fi

--- a/haoskiosk/tag-input-devices.sh
+++ b/haoskiosk/tag-input-devices.sh
@@ -24,6 +24,9 @@ for dev in /dev/input/event*; do
     # Get device path to check if USB
     devpath=$(udevadm info "$dev" | grep -m1 DEVPATH | cut -d= -f2)
     if [[ ! $devpath =~ /usb[0-9]+.*[0-9]{4}:[0-9A-Fa-f]{4}:[0-9A-Fa-f]{4} ]]; then
+        # Trigger udev to process existing tags
+        udevadm test "$devpath" >/dev/null 2>&
+        
         echo "$devname: Skipped (non-USB)"
         continue
     fi

--- a/haoskiosk/tag-input-devices.sh
+++ b/haoskiosk/tag-input-devices.sh
@@ -22,11 +22,17 @@ for dev in /dev/input/event*; do
     input_num=${devname#event}
 
     # Get device path to check if USB
-    devpath=$((udevadm info "$dev" | grep -m1 DEVPATH | cut -d= -f2)
+    udevadm_info=$(udevadm info "$dev")
+    devpath=$(echo "$udevadm_info" | grep -m1 DEVPATH | cut -d= -f2)
     if [[ ! $devpath =~ /usb[0-9]+.*[0-9]{4}:[0-9A-Fa-f]{4}:[0-9A-Fa-f]{4} ]]; then
+        #Get Devtype
+        dev_type=$(echo "$udevadm_info" | grep -m1 ID_INPUT_ | cut -d= -f1)
+        echo $dev_type
         # Write tags to udev data
         {
             echo "ID_INPUT=1"
+            echo "$device_type=1"
+            echo "LIBINPUT_DEVICE_GROUP=input"
         } > "/run/udev/data/+input:input$input_num"
         
         # Trigger udev to process existing tags

--- a/haoskiosk/tag-input-devices.sh
+++ b/haoskiosk/tag-input-devices.sh
@@ -22,9 +22,10 @@ for dev in /dev/input/event*; do
     input_num=${devname#event}
 
     # Get device path to check if USB
-    devpath=$(udevadm info "$dev" | grep -m1 DEVPATH | cut -d= -f2)
+    udevadm_info=$(udevadm info "$dev")
+    devpath=$(echo $udevadm_info | grep -m1 DEVPATH | cut -d= -f2)
     if [[ ! $devpath =~ /usb[0-9]+.*[0-9]{4}:[0-9A-Fa-f]{4}:[0-9A-Fa-f]{4} ]]; then
-        echo $dev 
+        echo $udevadm_info
         # Trigger udev to process existing tags
         udevadm test "$devpath" >/dev/null 2>&1
 

--- a/haoskiosk/tag-input-devices.sh
+++ b/haoskiosk/tag-input-devices.sh
@@ -25,8 +25,8 @@ for dev in /dev/input/event*; do
     devpath=$(udevadm info "$dev" | grep -m1 DEVPATH | cut -d= -f2)
     if [[ ! $devpath =~ /usb[0-9]+.*[0-9]{4}:[0-9A-Fa-f]{4}:[0-9A-Fa-f]{4} ]]; then
         # Trigger udev to process existing tags
-        udevadm test "$devpath" >/dev/null 2>&
-        
+        udevadm test "$devpath" >/dev/null 2>&1
+
         echo "$devname: Skipped (non-USB)"
         continue
     fi


### PR DESCRIPTION
 **Touch Display 2 connected via DSI connector to a Pi 5 would display but not register touches.
This fix resolves https://github.com/puterboy/HAOS-kiosk/issues/20**

Rationale for fix stems from https://wayland.freedesktop.org/libinput/doc/latest/device-configuration-via-udev.html#hwdb, where

1. `libinput` only uses device nodes in the form of `/dev/input/eventX` where `X` is the number of the specific device
2. `udevadm info /sys/class/input/eventX` (where `X` is an event number), will always return a device tagged as `ID_INPUT=1` as well as `ID_INPUT_y=1` (where `ID_INPUT_y` is one of `ID_INPUT_KEYBOARD, ID_INPUT_KEY, ID_INPUT_MOUSE, ID_INPUT_TOUCHPAD, ID_INPUT_TOUCHSCREEN, ID_INPUT_TABLET, ID_INPUT_JOYSTICK, ID_INPUT_ACCELEROMETER`) - see https://wayland.freedesktop.org/libinput/doc/1.7.1/udev_config.html
3. The existing `HAOS-kiosk testing branch` file `tag-input-devices.sh` already enumerates the event list and queries `udevadm info /sys/class/input/eventX` to add some (possibly) missing _inferred_ tags to some USB devices.

- This fix simply triggers a reload of all properties according to existing tags, as reported by `udevadm info`.
- Should any of them have `ID_INPUT=1` as well as `ID_INPUT_y=1` (where `ID_INPUT_y` is one of `ID_INPUT_KEYBOARD, ID_INPUT_KEY, ID_INPUT_MOUSE, ID_INPUT_TOUCHPAD, ID_INPUT_TOUCHSCREEN, ID_INPUT_TABLET, ID_INPUT_JOYSTICK, ID_INPUT_ACCELEROMETER`), that is sufficient for `libinput` to detect the devices for use.

**Behavior BEFORE fix implemented:**

1. Open a ssh terminal
2. Type `apk add xinput` followed by enter.
3. Type `export DISPLAY=:0` followed by enter.
4. Type `xinput list` followed by enter.
5. The terminal returns only virtualized input devices as below:
```
⎡ Virtual core pointer                          id=2    [master pointer  (3)]
⎜   ↳ Virtual core XTEST pointer                id=4    [slave  pointer  (2)]
⎣ Virtual core keyboard                         id=3    [master keyboard (2)]
    ↳ Virtual core XTEST keyboard               id=5    [slave  keyboard (3)]
```
Output from the log file BEFORE fix:
```
[14:29:37] INFO: Tagging USB input devices for use by 'libinput'...
event0: Skipped (non-USB)
event1: Skipped (non-USB)
event2: Skipped (non-USB)
event3: Skipped (non-USB)
event4: Skipped (non-USB)
event5: Skipped (non-USB)
libinput list-devices found:
[14:29:37] INFO: No user 'xorg.conf' data provided, using default...
.
####################################xorg.conf###################################
################################################################################
# Add-on: HAOS Kiosk Display (haoskiosk)
# File: xorg.conf
# Version: 1.0.0
# Copyright Jeff Kosowsky
# Date: July 2025
#
# Minimal xorg.conf to work with OpenGL/DRI video and libinput mice & keyboards
#
################################################################################
Section "ServerLayout"
    Identifier     "DefaultLayout"
    Screen         0  "Screen0" 0 0
    InputDevice    "Keyboard0" "CoreKeyboard"
    InputDevice    "Mouse0" "CorePointer"
    InputDevice    "Touchscreen0" "CorePointer"
EndSection
Section "InputDevice"
    Identifier  "Keyboard0"
    Driver      "libinput"
EndSection
Section "InputDevice"
    Identifier  "Mouse0"
    Driver      "libinput"
EndSection
Section "InputDevice"
    Identifier  "Touchscreen0"
    Driver      "libinput"
    Option      "Tapping" "on"
EndSection
Section "Device"
    Identifier  "Card0"
    Driver      "modesetting"
    Option      "DRI" "3"
    Option "kmsdev" "/dev/dri/card1"
EndSection
Section "Monitor"
    Identifier "Monitor0"
EndSection
Section "Screen"
    Identifier "Screen0"
    Device     "Card0"
    Monitor    "Monitor0"
    DefaultDepth 24
EndSection
################################################################################
.
[14:29:37] INFO: Starting X on DISPLAY=:0...
X.Org X Server 1.21.1.18
X Protocol Version 11, Revision 0
Current Operating System: Linux 4844632f-haoskiosk 6.12.34-haos-raspi #1 SMP PREEMPT Wed Aug 13 08:59:29 UTC 2025 aarch64
Kernel command line: reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe cgroup_disable=memory numa_policy=interleave nvme.max_host_mem_size_mb=0  numa=fake=8 system_heap.max_order=0 smsc95xx.macaddr=2C:CF:67:D8:1E:8D vc_mem.mem_base=0x3fc00000 vc_mem.mem_size=0x40000000  zram.enabled=1 zram.num_devices=3 rootwait cgroup_enable=memory fsck.repair=yes console=tty0 root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd ro rauc.slot=A systemd.machine_id=7c153247645247a1b644a13c4ae26d80
Current version of pixman: 0.46.4
	Before reporting problems, check http://wiki.x.org
	to make sure that you have the latest version.
Markers: (--) probed, (**) from config file, (==) default setting,
	(++) from command line, (!!) notice, (II) informational,
	(WW) warning, (EE) error, (NI) not implemented, (??) unknown.
(==) Log file: "/var/log/Xorg.0.log", Time: Thu Aug 14 14:29:37 2025
(==) Using config file: "/etc/X11/xorg.conf"
(==) Using system config directory "/usr/share/X11/xorg.conf.d"
[14:29:38] INFO: Restored /dev/tty0 successfully...
[14:29:38] INFO: X server started successfully after 1 seconds...
[14:29:39] INFO: Openbox started successfully...
[14:29:39] INFO: Screen timeout disabled...
[14:29:39] INFO: All video outputs: Screen DSI-2 720x1280
[14:29:39] INFO: Connected video outputs: (Selected output marked with '*')
[14:29:39] INFO:   *[1] DSI-2
[14:29:39] INFO: Rotating DSI-2: right
[14:29:39] INFO: Setting Keyboard Layout: us
rules:      evdev
model:      pc105
layout:     us
[14:29:39] INFO: Launching Luakit browser: http://localhost:8123/dashboard-default
```

**Behavior AFTER fix implemented:**

1. Open a ssh terminal
2. Type `apk add xinput` followed by enter.
3. Type `export DISPLAY=:0` followed by enter.
4. Type `xinput list` followed by enter.
5. The terminal returns both virtualized input devices and true physical hardware that `libinput` supports as below:
```
⎡ Virtual core pointer                          id=2    [master pointer  (3)]
⎜   ↳ Virtual core XTEST pointer                id=4    [slave  pointer  (2)]
⎜   ↳ 11-005d Goodix Capacitive TouchScreen     id=6    [slave  pointer  (2)]
⎜   ↳ vc4-hdmi-0                                id=8    [slave  pointer  (2)]
⎜   ↳ vc4-hdmi-1                                id=9    [slave  pointer  (2)]
⎣ Virtual core keyboard                         id=3    [master keyboard (2)]
    ↳ Virtual core XTEST keyboard               id=5    [slave  keyboard (3)]
    ↳ pwr_button                                id=7    [slave  keyboard (3)]
    ↳ 11-005d Goodix Capacitive TouchScreen     id=10   [slave  keyboard (3)]
    ↳ vc4-hdmi-0                                id=11   [slave  keyboard (3)]
    ↳ vc4-hdmi-1                                id=12   [slave  keyboard (3)]
```

Output from the log file AFTER fix:
```
[14:03:28] INFO: Tagging USB input devices for use by 'libinput'...
event0: Reloaded (non-USB)
event1: Reloaded (non-USB)
event2: Reloaded (non-USB)
event3: Reloaded (non-USB)
event4: Reloaded (non-USB)
event5: Reloaded (non-USB)
libinput list-devices found:
  event5:                  11-005d Goodix Capacitive TouchScreen
  event0:                  pwr_button
  event1:                  vc4-hdmi-0
  event3:                  vc4-hdmi-1
[14:03:29] INFO: No user 'xorg.conf' data provided, using default...
.
####################################xorg.conf###################################
################################################################################
# Add-on: HAOS Kiosk Display (haoskiosk)
# File: xorg.conf
# Version: 1.0.0
# Copyright Jeff Kosowsky
# Date: July 2025
#
# Minimal xorg.conf to work with OpenGL/DRI video and libinput mice & keyboards
#
################################################################################
Section "ServerLayout"
    Identifier     "DefaultLayout"
    Screen         0  "Screen0" 0 0
    InputDevice    "Keyboard0" "CoreKeyboard"
    InputDevice    "Mouse0" "CorePointer"
    InputDevice    "Touchscreen0" "CorePointer"
EndSection
Section "InputDevice"
    Identifier  "Keyboard0"
    Driver      "libinput"
EndSection
Section "InputDevice"
    Identifier  "Mouse0"
    Driver      "libinput"
EndSection
Section "InputDevice"
    Identifier  "Touchscreen0"
    Driver      "libinput"
    Option      "Tapping" "on"
EndSection
Section "Device"
    Identifier  "Card0"
    Driver      "modesetting"
    Option      "DRI" "3"
    Option "kmsdev" "/dev/dri/card1"
EndSection
Section "Monitor"
    Identifier "Monitor0"
EndSection
Section "Screen"
    Identifier "Screen0"
    Device     "Card0"
    Monitor    "Monitor0"
    DefaultDepth 24
EndSection
################################################################################
.
[14:03:29] INFO: Starting X on DISPLAY=:0...
X.Org X Server 1.21.1.18
X Protocol Version 11, Revision 0
Current Operating System: Linux af9e4035-haoskiosk 6.12.34-haos-raspi #1 SMP PREEMPT Wed Aug 13 08:59:29 UTC 2025 aarch64
Kernel command line: reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe cgroup_disable=memory numa_policy=interleave nvme.max_host_mem_size_mb=0  numa=fake=8 system_heap.max_order=0 smsc95xx.macaddr=2C:CF:67:D8:1E:8D vc_mem.mem_base=0x3fc00000 vc_mem.mem_size=0x40000000  zram.enabled=1 zram.num_devices=3 rootwait cgroup_enable=memory fsck.repair=yes console=tty0 root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd ro rauc.slot=A systemd.machine_id=7c153247645247a1b644a13c4ae26d80
Current version of pixman: 0.46.4
	Before reporting problems, check http://wiki.x.org
	to make sure that you have the latest version.
Markers: (--) probed, (**) from config file, (==) default setting,
	(++) from command line, (!!) notice, (II) informational,
	(WW) warning, (EE) error, (NI) not implemented, (??) unknown.
(==) Log file: "/var/log/Xorg.0.log", Time: Thu Aug 14 14:03:29 2025
(==) Using config file: "/etc/X11/xorg.conf"
(==) Using system config directory "/usr/share/X11/xorg.conf.d"
[14:03:30] INFO: Restored /dev/tty0 successfully...
[14:03:31] INFO: X server started successfully after 1 seconds...
[14:03:31] INFO: Openbox started successfully...
[14:03:31] INFO: Screen timeout disabled...
[14:03:31] INFO: All video outputs: Screen DSI-2 720x1280
[14:03:31] INFO: Connected video outputs: (Selected output marked with '*')
[14:03:31] INFO:   *[1] DSI-2
[14:03:32] INFO: Rotating DSI-2: right
[14:03:32] INFO: Mapping: input device [6|11-005d Goodix Capacitive TouchScreen] -->  DSI-2 [SUCCESS]
[14:03:32] INFO: Setting Keyboard Layout: us
rules:      evdev
model:      pc105
layout:     us
[14:03:32] INFO: Launching Luakit browser: http://localhost:8123/dashboard-default
```