### PR TITLE
Add Virtual Keyboard Support to Touchscreens in Testing branch

### DIFF
--- a/haoskiosk/Dockerfile
+++ b/haoskiosk/Dockerfile
@@ -34,7 +34,6 @@ RUN apk update && apk add --no-cache \
     setxkbmap \
     bash \
     onboard \
-    at-spi2-core \
     && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.21/community luakit=2.3.6-r0 \
     && rm -rf /var/cache/apk/*
 

--- a/haoskiosk/Dockerfile
+++ b/haoskiosk/Dockerfile
@@ -34,6 +34,7 @@ RUN apk update && apk add --no-cache \
     setxkbmap \
     bash \
     onboard \
+    at-spi2-core \
     && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.21/community luakit=2.3.6-r0 \
     && rm -rf /var/cache/apk/*
 

--- a/haoskiosk/README.md
+++ b/haoskiosk/README.md
@@ -144,7 +144,7 @@ NOTE: To enter custom settings menu, press and hold the 'enter' key, and then th
 
 ### PERSIST ONSCREEN KEYBOARD CONFIG
 
-Save and Restore user-defined keyboard settings across Add-on restarts if 'true'.
+Save and Restore user-defined keyboard settings across Add-on restarts if 'true'.  
 Use default keyboard settings across Add-on restarts if 'false'.
 
 NOTE: If USE ONSCREEN KEYBOARD is 'false', this setting has no effect.

--- a/haoskiosk/README.md
+++ b/haoskiosk/README.md
@@ -132,106 +132,21 @@ Manually, launch `luakit` (e.g.,
 `luakit -U localhost:8123/<your-dashboard>`) from Docker container.\
 E.g., `sudo docker exec -it addon_haoskiosk bash`
 
-### USE VIRTUAL KEYBOARD
+### USE ONSCREEN KEYBOARD
 
-Launch a Onboard onscreen keyboard (Typically used for stand-alone touch screens).<br/>
-Supported keyboard language should be inherited from regional settings, which are any of:
-- bg_BG
-- da_DK
-- de_AT
-- de_CH
-- de_DE
-- el_GR
-- en_AU
-- en_CA
-- en_GB
-- en_US
-- eo_XX
-- es_ES
-- fr_FR
-- ga_IE
-- gd_GB
-- it_IT
-- lb_LU
-- nl_AN
-- nl_AW
-- nl_BE
-- nl_NL
-- nl_SR
-- pl_PL
-- pt_BR
-- pt_PT
-- ro_RO
-- ru_RU
-- sv_SE
-- tr_TR
+Launch an Onscreen keyboard (typically used for stand-alone touch screens) if 'true'.  
+Supported keyboard language should be inherited from regional settings.
 
-(Default: False)
+NOTE: Use a two-finger pinch gesture to enable resize (by dragging edge handles) or move (by dragging center handle).  
+NOTE: To enter custom settings menu, press and hold the 'enter' key, and then the 'tools' key.
 
-### VIRTUAL KEYBOARD LAYOUT
+(Default: false)
 
-Configure onscreen keyboard layout to be any of:
-- Compact.onboard
-- Full Keyboard.onboard
-- Grid.onboard
-- Phone.onboard
-- Small.onboard
-- Whiteboard.onboard
-- Whiteboard_wide.onboard
+### PERSIST ONSCREEN KEYBOARD CONFIG
 
-(Default: Small.onboard)
+Save and Restore user-defined keyboard settings across Add-on restarts if 'true'.
+Use default keyboard settings across Add-on restarts if 'false'.
 
-### VIRTUAL KEYBOARD THEME
+NOTE: If USE ONSCREEN KEYBOARD is 'false', this setting has no effect.
 
-Configure onscreen keyboard theme to be any of (be sure to preserve spaces in names):
-- Ambiance.theme
-- Blackboard.theme
-- Classic Onboard.theme
-- DarkRoom.theme
-- Droid.theme
-- HighContrast.theme
-- HighContrastInverse.theme
-- LowContrast.theme
-- ModelM.theme
-- Nightshade.theme
-- Typist.theme
-
-(Default: Blackboard.theme)
-
-### VIRTUAL KEYBOARD_COLORS
-
-Configure onscreen keyboard colors to be any of (be sure to preserve spaces in names):
-- Aubergine.colors
-- Black.colors
-- Charcoal.colors
-- Classic Onboard.colors
-- DarkRoom.colors
-- Granite.colors
-- HighContrast.colors
-- HighContrastInverseBlack.colors
-- HighContrastInverseBlue.colors
-- LowContrast.colors
-- ModelM.colors
-- Typist.colors
-
-(Default: Charcoal.colors)
-
-### VIRTUAL KEYBOARD HEIGHT
-
-An integer Number greater than zero which is the initial height of the keyboard
-(Default: 360)
-
-### VIRTUAL KEYBOARD WIDTH
-
-An integer Number greater than zero which is the initial width of the keyboard
-(Default: 1280)
-
-### VIRTUAL KEYBOARD XPOS
-
-An integer Number greater than or equal to zero which is the initial X coordinate of the keyboard
-(Default: 640)
-
-### VIRTUAL KEYBOARD YPOS
-
-An integer Number greater than or equal to zero which is the initial Y coordinate of the keyboard
-(Default: 360)
+(Default: false)

--- a/haoskiosk/config.yaml
+++ b/haoskiosk/config.yaml
@@ -70,8 +70,8 @@ options:
   xorg_append_replace: "append"
   debug_mode: false
   keyboard_layout: us
-  onscreen_keyboard: "false"
-  persist_onscreen_keyboard_config: "false"
+  onscreen_keyboard: false
+  persist_onscreen_keyboard_config: false
 
 schema:
   ha_username: str

--- a/haoskiosk/config.yaml
+++ b/haoskiosk/config.yaml
@@ -18,6 +18,9 @@ host_network: true
 init: false
 ingress: true
 
+map:
+  - addon_config:rw
+  
 devices:
   - /dev/dri/card0
   - /dev/dri/card1

--- a/haoskiosk/config.yaml
+++ b/haoskiosk/config.yaml
@@ -70,14 +70,8 @@ options:
   xorg_append_replace: "append"
   debug_mode: false
   keyboard_layout: us
-  use_virtual_keyboard: false
-  virtual_keyboard_layout: ""
-  virtual_keyboard_theme: ""
-  virtual_keyboard_colors: ""
-  virtual_keyboard_height: 360
-  virtual_keyboard_width: 1280
-  virtual_keyboard_xpos: 640
-  virtual_keyboard_ypos: 360
+  onscreen_keyboard: "false"
+  persist_onscreen_keyboard_config: "false"
 
 schema:
   ha_username: str
@@ -98,14 +92,8 @@ schema:
   xorg_conf: str?
   xorg_append_replace: list(append|replace)
   debug_mode: bool
-  use_virtual_keyboard: bool
-  virtual_keyboard_layout: str?
-  virtual_keyboard_theme: str?
-  virtual_keyboard_colors: str?
-  virtual_keyboard_height: int(1,)
-  virtual_keyboard_width: int(1,)
-  virtual_keyboard_xpos: int(0,)
-  virtual_keyboard_ypos: int(0,)
+  onscreen_keyboard: bool
+  persist_onscreen_keyboard_config: bool
 
 translations:
   - en

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -56,6 +56,7 @@ bashio::log.info "$(date) [Version: $VERSION]"
 #### Clean up on exit:
 TTY0_DELETED="" #Need to set to empty string since runs with nounset=on (like set -u)
 KBD_PERSIST_FILE="/config/usr_custom_keyboad.ini"
+KBD_OPTIONS_FILE="/config/usr_keyboad_default_opts.txt"
 cleanup() {
     local exit_code=$?
 	# Always save keyboard info
@@ -366,6 +367,9 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
    		dconf load / < "$KBD_PERSIST_FILE"	
  	else
   		bashio::log.info "Using default onscreen keyboard setup"
+
+ 		### Save a copy of all possible settings
+   		gsettings list-recursively org.onboard > "$KBD_OPTIONS_FILE"
 
  		### Set default layout, theme and colors
 		dbus-run-session -- dconf write /org/onboard/layout \''/usr/share/onboard/layouts/Small.onboard'\'

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -56,7 +56,7 @@ bashio::log.info "$(date) [Version: $VERSION]"
 #### Clean up on exit:
 TTY0_DELETED="" #Need to set to empty string since runs with nounset=on (like set -u)
 KBD_PERSIST_FILE="/config/usr_custom_keyboad.ini"
-KBD_OPTIONS_FILE="/config/usr_keyboad_default_opts.txt"
+KBD_DEFAULT_OPTIONS_FILE="/config/usr_keyboad_default_opts.txt"
 cleanup() {
     local exit_code=$?
 	# Always save keyboard info
@@ -368,8 +368,9 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
  	else
   		bashio::log.info "Using default onscreen keyboard setup"
 
- 		### Save a copy of all possible settings
-   		gsettings list-recursively org.onboard > "$KBD_OPTIONS_FILE"
+ 		### Save a copy of all default values of possible settings
+   		gsettings reset-recursively org.onboard
+   		gsettings list-recursively org.onboard > "$KBD_DEFAULT_OPTIONS_FILE"
 
  		### Set default layout, theme and colors
 		dbus-run-session -- dconf write /org/onboard/layout \''/usr/share/onboard/layouts/Small.onboard'\'
@@ -404,8 +405,11 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
 		dbus-run-session -- dconf write /org/onboard/window/force-to-top true # always show in front
 	 	dbus-run-session -- gsettings set org.gnome.desktop.interface toolkit-accessibility true # disable gnome assessibility popup
 
-   		## Start Keyboard minimized (should auto show when clicking on text input field)
+   		### Start Keyboard minimized (should auto show when clicking on text input field)
 	 	dbus-run-session -- dconf write /org/onboard/start-minimized true
+
+		### Save a copy of modifie settings once in case system aborts before cleanup runs
+   		dconf dump / > "$KBD_PERSIST_FILE"
 	fi
 
 	### Launch keyboard

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -66,6 +66,8 @@ cleanup() {
     exit "$exit_code"
 }
 trap cleanup INT EXIT
+unset ONSCREEN_KEYBOARD
+unset PERSIST_ONSCREEN_KEYBOARD_CONFIG
 
 ################################################################################
 #### Get config variables from HA add-on & set environment variables

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -343,7 +343,7 @@ bashio::log.info "Setting keyboard layout and language to: $KEYBOARD_LAYOUT"
 setxkbmap -query  | sed 's/^/  /' #Log layout
 
 #### Launch virtual keyboard if needed
-KBD_PERSIST_FILE='/addon_config/usr_custom_keybd.ini'
+KBD_PERSIST_FILE='/addon_config/af9e4035_haoskiosk/usr_custom_keybd.ini'
 
 if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	bashio::log.info "Configuring onscreen keyboard"

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -403,9 +403,10 @@ if [ "$USE_VIRTUAL_KEYBOARD" = true ]; then
 	# dbus-run-session -- dconf write /org/onboard/window/landscape/y  "$VIRTUAL_KEYBOARD_YPOS" # set default y coordinate
 
     dbus-run-session -- dconf write /org/onboard/auto-show true # enable auto show
-	dbus-run-session -- dconf write /org/onboard/auto-show/enabled false # initially hide onboard keyboard
+	dbus-run-session -- dconf write /org/onboard/auto-show/enabled true # enable onboard keyboard
 	dbus-run-session -- dconf write /org/onboard/auto-show/tablet-mode-detection-enabled false # shows keyboard only in tablet mode. I had to disable it to make it work
 	dbus-run-session -- dconf write /org/onboard/window/force-to-top true # always show in front
+ 
 	dbus-run-session -- gsettings set org.gnome.desktop.interface toolkit-accessibility true # disable gnome assessibility popup
 	bashio::log.info "Starting onboard keyboard"
 	dbus-run-session onboard & # launches the keyboard

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -387,15 +387,11 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	    fi
 
 	  	### Enable keyboard to auto appear when inputting text
-	    ### dbus-run-session -- dconf write /org/onboard/auto-show true # enable auto show
-		#dbus-run-session -- dconf write /org/onboard/start-minimized true # hide keyboard at startup
 		dbus-run-session -- dconf write /org/onboard/xembed-onboard false # do not start in XEmbed mode 
 		dbus-run-session -- dconf write /org/onboard/auto-show/enabled true # enable auto show
 		dbus-run-session -- dconf write /org/onboard/auto-show/tablet-mode-detection-enabled false # shows keyboard only in tablet mode. I had to disable it to make it work
 		dbus-run-session -- dconf write /org/onboard/window/force-to-top true # always show in front
 	 	dbus-run-session -- gsettings set org.gnome.desktop.interface toolkit-accessibility true # disable gnome assessibility popup
-	    dbus-run-session -- gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false # hide keyboard at startup
-	
 	fi
 
 	### Launch keyboard

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -64,8 +64,10 @@ trap kill_luakit SIGTERM
 TTY0_DELETED="" #Need to set to empty string since runs with nounset=on (like set -u)
 cleanup() {
     local exit_code=$?
-    [ -n "$(jobs -p)" ] && kill "$(jobs -p)"
-    [ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
+	if [ "$LUAKIT_PID" -ne "$exit_code" ]
+    	[ -n "$(jobs -p)" ] && kill "$(jobs -p)"
+    	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
+	fi
     exit "$exit_code"
 }
 trap cleanup INT TERM EXIT
@@ -433,6 +435,7 @@ if [ "$DEBUG_MODE" != true ]; then
     bashio::log.info "Launching Luakit browser: $HA_URL/$HA_DASHBOARD"
     luakit -U "$HA_URL/$HA_DASHBOARD" &
     LUAKIT_PID=$!
+	bashio::log.info "Waiting for PID: $LUAKIT_PID to end..."
     wait "$LUAKIT_PID" #Wait for luakit to exit
 
 	 #### Persist virtual keyboard settings if needed

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -360,7 +360,7 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
  		rm -f "$KBD_PERSIST_FILE"
 	fi
 
- 	if [ -f "$KBD_PERSIST_FILE" ]; then
+ 	if [ -f "$KBD_PERSIST_FILE" ] && [ "$PERSIST_ONSCREEN_KEYBOARD_CONFIG" = true ]; then
   		bashio::log.info "Restoring onscreen keyboard setup"
 
  		### Load all non-default settings from file and apply them

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -64,7 +64,7 @@ cleanup() {
 	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
     exit "$exit_code"
 }
-trap cleanup INT QUIT ABRT TERM EXIT
+trap cleanup INT TERM EXIT
 #trap cleanup HUP INT QUIT ABRT TERM EXIT
 
 

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -59,7 +59,7 @@ KBD_FILE_MUST_PERSIST=""
 KBD_PERSIST_FILE="/config/usr_custom_keyboad.ini"
 cleanup() {
     local exit_code=$?
-	[ -n "$KBD_FILE_MUST_PERSIST" ] && ! [ $(rm -f "$KBD_PERSIST_FILE) ] && dconf dump / > "$KBD_PERSIST_FILE"
+	#[ -n "$KBD_FILE_MUST_PERSIST" ] && ! [ $(rm -f "$KBD_PERSIST_FILE) ] && dconf dump / > "$KBD_PERSIST_FILE"
 	[ -n "$(jobs -p)" ] && kill "$(jobs -p)"
 	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
     exit "$exit_code"

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -67,8 +67,8 @@ cleanup() {
 	if [ "$LUAKIT_PID" -ne "$exit_code" ]
     	[ -n "$(jobs -p)" ] && kill "$(jobs -p)"
     	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
-	fi
-    exit "$exit_code"
+	    exit "$exit_code"
+    fi
 }
 trap cleanup INT TERM EXIT
 

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -64,8 +64,8 @@ cleanup() {
 	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
     exit "$exit_code"
 }
-trap cleanup HUP INT QUIT ABRT TERM EXIT
-#trap cleanup INT TERM EXIT
+trap cleanup INT TERM EXIT
+#trap cleanup HUP INT QUIT ABRT TERM EXIT
 
 
 ################################################################################

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -399,7 +399,6 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
 		dbus-run-session -- dconf write /org/onboard/auto-show/tablet-mode-detection-enabled false # shows keyboard only in tablet mode. I had to disable it to make it work
 		dbus-run-session -- dconf write /org/onboard/window/force-to-top true # always show in front
 	 	dbus-run-session -- gsettings set org.gnome.desktop.interface toolkit-accessibility true # disable gnome assessibility popup
-   		dbus-send --type=method_call --print-reply --dest=org.onboard.Onboard /org/onboard/Onboard/Keyboard org.onboard.Onboard.Keyboard.Hide # default hide keyboard
 	fi
 
 	### Launch keyboard

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -399,6 +399,9 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
 		dbus-run-session -- dconf write /org/onboard/auto-show/tablet-mode-detection-enabled false # shows keyboard only in tablet mode. I had to disable it to make it work
 		dbus-run-session -- dconf write /org/onboard/window/force-to-top true # always show in front
 	 	dbus-run-session -- gsettings set org.gnome.desktop.interface toolkit-accessibility true # disable gnome assessibility popup
+
+   		## Start Keyboard minimized (should auto show when clicking on text input field)
+	 	dbus-run-session -- dconf write /org/onboard/start-minimized true
 	fi
 
 	### Launch keyboard

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -343,7 +343,7 @@ bashio::log.info "Setting keyboard layout and language to: $KEYBOARD_LAYOUT"
 setxkbmap -query  | sed 's/^/  /' #Log layout
 
 #### Launch virtual keyboard if needed
-KBD_PERSIST_FILE='/data/usr_custom_keybd.ini'
+KBD_PERSIST_FILE='/addon_config/usr_custom_keybd.ini'
 
 if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	bashio::log.info "Configuring onscreen keyboard"

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -375,7 +375,7 @@ if [ "$USE_VIRTUAL_KEYBOARD" = true ]; then
  			dbus-run-session -- dconf write /org/onboard/theme-settings/color-scheme \'"$KBD_COLOR_FILE"\' # set default colors
 		fi
 	fi
- 	if [ "$ROTATE_DISPLAY" = normal || "$ROTATE_DISPLAY" = inverted ] ; then
+ 	if [ "$ROTATE_DISPLAY" = normal ] || [ "$ROTATE_DISPLAY" = inverted ] ; then
   		SCRN_WIDTH=$(xrandr --query --verbose | awk '/ width/ {print $3}')
   		SCRN_HEIGHT=$(xrandr --query --verbose | awk '/ height/ {print $3}')
     else

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -355,9 +355,9 @@ setxkbmap -query  | sed 's/^/  /' #Log layout
 if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	bashio::log.info "Configuring onscreen keyboard"
 
-	#if [ "$PERSIST_ONSCREEN_KEYBOARD_CONFIG" = false ]
-  	#	rm -f "$KBD_PERSIST_FILE"
- 	#fi
+	if [ "$PERSIST_ONSCREEN_KEYBOARD_CONFIG" = true ]; then
+ 		rm -f "$KBD_PERSIST_FILE"
+	fi
 
  	if [ -f "$KBD_PERSIST_FILE" ]; then
   		bashio::log.info "Restoring onscreen keyboard setup"

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -244,6 +244,8 @@ done
 if [ -n "$TTY0_DELETED" ]; then
     if mknod -m 620 /dev/tty0 c 4 0; then
         bashio::log.info "Restored /dev/tty0 successfully..."
+		# Prevent cleanup code from repating the above
+		TTY0_DELETED=""
     else
         bashio::log.error "Failed to restore /dev/tty0..."
     fi

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -64,13 +64,11 @@ trap kill_luakit SIGTERM
 TTY0_DELETED="" #Need to set to empty string since runs with nounset=on (like set -u)
 cleanup() {
     local exit_code=$?
-	if [ "$LUAKIT_PID" -ne "$exit_code" ]
-    	[ -n "$(jobs -p)" ] && kill "$(jobs -p)"
-    	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
+	[ -n "$(jobs -p)" ] && kill "$(jobs -p)"
+	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
     exit "$exit_code"
-	fi
 }
-trap cleanup INT TERM EXIT
+trap cleanup INT EXIT
 
 ################################################################################
 #### Get config variables from HA add-on & set environment variables

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -375,7 +375,7 @@ if [ "$USE_VIRTUAL_KEYBOARD" = true ]; then
  			dbus-run-session -- dconf write /org/onboard/theme-settings/color-scheme \'"$KBD_COLOR_FILE"\' # set default colors
 		fi
 	fi
- 	if [ "$ROTATE_DISPLAY" = normal || "$ROTATE_DISPLAY" = inverted] ; then
+ 	if [ "$ROTATE_DISPLAY" = normal || "$ROTATE_DISPLAY" = inverted ] ; then
   		SCRN_WIDTH=$(xrandr --query --verbose | awk '/ width/ {print $3}')
   		SCRN_HEIGHT=$(xrandr --query --verbose | awk '/ height/ {print $3}')
     else

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -396,7 +396,7 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	 	dbus-run-session -- gsettings set org.gnome.desktop.interface toolkit-accessibility true # disable gnome assessibility popup
 	  	#dbus-run-session -- gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true
 	    #dbus-run-session -- gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false
-		#dbus-send --type=method_call --print-reply --dest=org.onboard.Onboard /org/onboard/Onboard/Keyboard org.onboard.Onboard.Keyboard.Hide
+		dbus-send --type=method_call --print-reply --dest=org.onboard.Onboard /org/onboard/Onboard/Keyboard org.onboard.Onboard.Keyboard.Hide
 	
 	fi
 

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -394,9 +394,7 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
 		dbus-run-session -- dconf write /org/onboard/auto-show/tablet-mode-detection-enabled false # shows keyboard only in tablet mode. I had to disable it to make it work
 		dbus-run-session -- dconf write /org/onboard/window/force-to-top true # always show in front
 	 	dbus-run-session -- gsettings set org.gnome.desktop.interface toolkit-accessibility true # disable gnome assessibility popup
-	  	#dbus-run-session -- gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true
-	    #dbus-run-session -- gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false
-		dbus-send --type=method_call --print-reply --dest=org.onboard.Onboard /org/onboard/Onboard/Keyboard org.onboard.Onboard.Keyboard.Hide
+	    dbus-run-session -- gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false # hide keyboard at startup
 	
 	fi
 
@@ -436,6 +434,7 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
  		bashio::log.info "Backing up onscreen keyboard setup"
    
  		# Save only non-default settings
+   		rm -f $"KBD_PERSIST_FILE"
    		dconf dump / > $"KBD_PERSIST_FILE"
 	fi
 fi

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -343,7 +343,7 @@ bashio::log.info "Setting keyboard layout and language to: $KEYBOARD_LAYOUT"
 setxkbmap -query  | sed 's/^/  /' #Log layout
 
 #### Launch virtual keyboard if needed
-KBD_PERSIST_FILE='/addon_config/af9e4035_haoskiosk/usr_custom_keybd.ini'
+KBD_PERSIST_FILE='/addon_config/af9e4035_haoskiosk/usr_custom_keyboad.ini'
 
 if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	bashio::log.info "Configuring onscreen keyboard"
@@ -403,16 +403,6 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	### Launch keyboard
  	bashio::log.info "Starting onscreen keyboard"
 	dbus-run-session onboard &
-fi
-
-#### Persist virtual keyboard settings if needed
-if [ "$ONSCREEN_KEYBOARD" = true ]; then
-	if [ "$PERSIST_ONSCREEN_KEYBOARD_CONFIG" = true ]; then
- 		bashio::log.info "Backing up onscreen keyboard setup"
-   
- 		# Save only non-default settings
-   		dconf dump / > $"KBD_PERSIST_FILE"
-	fi
 fi
 
 #### Poll to send <Control-r> when screen unblanks to force reload of luakit page if BROWSWER_REFRESH set

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -64,7 +64,7 @@ cleanup() {
 	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
     exit "$exit_code"
 }
-trap cleanup INT TERM EXIT
+trap cleanup HUP INT QUIT ABRT TERM EXIT
 
 ################################################################################
 #### Get config variables from HA add-on & set environment variables

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -59,13 +59,13 @@ KBD_FILE_MUST_PERSIST=""
 KBD_PERSIST_FILE="/config/usr_custom_keyboad.ini"
 cleanup() {
     local exit_code=$?
-	#[ -n "$KBD_FILE_MUST_PERSIST" ] && ! [ $(rm -f "$KBD_PERSIST_FILE) ] && dconf dump / > "$KBD_PERSIST_FILE"
+	#[ -n "$KBD_FILE_MUST_PERSIST" ] && [ ! [ $(rm -f "$KBD_PERSIST_FILE) ] ] && [ $(dconf dump / > "$KBD_PERSIST_FILE") ]
 	[ -n "$(jobs -p)" ] && kill "$(jobs -p)"
 	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
     exit "$exit_code"
 }
-trap cleanup INT TERM EXIT
-#trap cleanup HUP INT QUIT ABRT TERM EXIT
+trap cleanup HUP INT QUIT ABRT TERM EXIT
+#trap cleanup INT TERM EXIT
 
 
 ################################################################################

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -344,7 +344,7 @@ setxkbmap -query  | sed 's/^/  /' #Log layout
 
 #### Launch virtual keyboard if needed
 #KBD_PERSIST_FILE='/addon_config/af9e4035_haoskiosk/usr_custom_keyboad.ini'
-KBD_PERSIST_FILE='/config/usr_custom_keyboad.ini'
+KBD_PERSIST_FILE="/config/usr_custom_keyboad.ini"
 
 if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	bashio::log.info "Configuring onscreen keyboard"
@@ -353,12 +353,12 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
   		bashio::log.info "Restoring onscreen keyboard setup"
 
  		### Load all non-default settings from file and apply them
-   		dconf load / < $"KBD_PERSIST_FILE"	
+   		dconf load / < "$KBD_PERSIST_FILE"	
  	else
   		bashio::log.info "Using default onscreen keyboard setup"
 
   		### Delete settings file if it exists 
- 		rm -f $"KBD_PERSIST_FILE"
+ 		rm -f "$KBD_PERSIST_FILE"
 
  		### Set default layout, theme and colors
 		dbus-run-session -- dconf write /org/onboard/layout \''/usr/share/onboard/layouts/Small.onboard'\'
@@ -395,7 +395,7 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	 	dbus-run-session -- gsettings set org.gnome.desktop.interface toolkit-accessibility true # disable gnome assessibility popup
 
 		#testing
-   		dconf dump / > $"KBD_PERSIST_FILE"
+   		dconf dump / > "$KBD_PERSIST_FILE"
 	fi
 
 	### Launch keyboard
@@ -434,7 +434,7 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
  		bashio::log.info "Backing up onscreen keyboard setup"
    
  		# Save only non-default settings
-   		rm -f $"KBD_PERSIST_FILE"
-   		dconf dump / > $"KBD_PERSIST_FILE"
+   		rm -f "$KBD_PERSIST_FILE"
+   		dconf dump / > "$KBD_PERSIST_FILE"
 	fi
 fi

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -386,11 +386,17 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	fi
 
  	### Enable keyboard to auto appear when inputting text
-    dbus-run-session -- dconf write /org/onboard/auto-show true # enable auto show
-	dbus-run-session -- dconf write /org/onboard/auto-show/enabled true # enable onboard keyboard
+    ### dbus-run-session -- dconf write /org/onboard/auto-show true # enable auto show
+	#dbus-run-session -- dconf write /org/onboard/start-minimized true # hide keyboard at startup
+	dbus-run-session -- dconf write /org/onboard/xembed-onboard false # do not start in XEmbed mode 
+	dbus-run-session -- dconf write /org/onboard/auto-show/enabled true # enable auto show
 	dbus-run-session -- dconf write /org/onboard/auto-show/tablet-mode-detection-enabled false # shows keyboard only in tablet mode. I had to disable it to make it work
 	dbus-run-session -- dconf write /org/onboard/window/force-to-top true # always show in front
  	dbus-run-session -- gsettings set org.gnome.desktop.interface toolkit-accessibility true # disable gnome assessibility popup
+  	#dbus-run-session -- gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true
+    #dbus-run-session -- gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false
+	#dbus-send --type=method_call --print-reply --dest=org.onboard.Onboard /org/onboard/Onboard/Keyboard org.onboard.Onboard.Keyboard.Hide
+
 
 	### Launch keyboard
  	bashio::log.info "Starting onscreen keyboard"

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -403,7 +403,7 @@ if [ "$USE_VIRTUAL_KEYBOARD" = true ]; then
 	# dbus-run-session -- dconf write /org/onboard/window/landscape/y  "$VIRTUAL_KEYBOARD_YPOS" # set default y coordinate
 
     dbus-run-session -- dconf write /org/onboard/auto-show true # enable auto show
-	dbus-run-session -- dconf write /org/onboard/auto-show/enabled true # enable onboard keyboard
+	dbus-run-session -- dconf write /org/onboard/auto-show/enabled false # initially hide onboard keyboard
 	dbus-run-session -- dconf write /org/onboard/auto-show/tablet-mode-detection-enabled false # shows keyboard only in tablet mode. I had to disable it to make it work
 	dbus-run-session -- dconf write /org/onboard/window/force-to-top true # always show in front
 	dbus-run-session -- gsettings set org.gnome.desktop.interface toolkit-accessibility true # disable gnome assessibility popup

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -64,7 +64,9 @@ cleanup() {
 	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
     exit "$exit_code"
 }
-trap cleanup HUP INT QUIT ABRT TERM EXIT
+trap cleanup INT QUIT ABRT TERM EXIT
+#trap cleanup HUP INT QUIT ABRT TERM EXIT
+
 
 ################################################################################
 #### Get config variables from HA add-on & set environment variables

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -374,11 +374,11 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
   
 		### Determine screen geometry as reported by X
      	if [ "$ROTATE_DISPLAY" = normal ] || [ "$ROTATE_DISPLAY" = inverted ] ; then
-	  		SCRN_WIDTH=$(xrandr --query --verbose | awk '/ width/ {print $3}')
-	  		SCRN_HEIGHT=$(xrandr --query --verbose | awk '/ height/ {print $3}')
+	  		SCRN_WIDTH=$(xrandr --query --current --verbose | awk '/ width/ {print $3}')
+	  		SCRN_HEIGHT=$(xrandr --query --current --verbose | awk '/ height/ {print $3}')
 	    else
-	  		SCRN_WIDTH=$(xrandr --query --verbose | awk '/ height/ {print $3}')
-	  		SCRN_HEIGHT=$(xrandr --query --verbose | awk '/ width/ {print $3}')
+	  		SCRN_WIDTH=$(xrandr --query --current --verbose | awk '/ height/ {print $3}')
+	  		SCRN_HEIGHT=$(xrandr --query --current --verbose | awk '/ width/ {print $3}')
 	    fi
 
   		### Set default keyboard height (1/2 or 1/4 of screen), width (full width) and position (centered, flush with bottom)

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -59,7 +59,7 @@ KBD_FILE_MUST_PERSIST=""
 KBD_PERSIST_FILE="/config/usr_custom_keyboad.ini"
 cleanup() {
     local exit_code=$?
-	#[ -n "$KBD_FILE_MUST_PERSIST" ] && [ ! [ $(rm -f "$KBD_PERSIST_FILE) ] ] && [ $(dconf dump / > "$KBD_PERSIST_FILE") ]
+	[ -n "$KBD_FILE_MUST_PERSIST" ] && [ ! [ $(rm -f "$KBD_PERSIST_FILE) ] ] && [ $(dconf dump / > "$KBD_PERSIST_FILE") ]
 	[ -n "$(jobs -p)" ] && kill "$(jobs -p)"
 	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
     exit "$exit_code"

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -402,8 +402,6 @@ if [ "$USE_VIRTUAL_KEYBOARD" = true ]; then
 	# dbus-run-session -- dconf write /org/onboard/window/landscape/x  "$VIRTUAL_KEYBOARD_XPOS" # set default x coordinate
 	# dbus-run-session -- dconf write /org/onboard/window/landscape/y  "$VIRTUAL_KEYBOARD_YPOS" # set default y coordinate
 
-    dbus-run-session -- dconf write /org/onboard/start-minimized true # dont show untill we click on text field
-
     dbus-run-session -- dconf write /org/onboard/auto-show true # enable auto show
 	dbus-run-session -- dconf write /org/onboard/auto-show/enabled true # enable onboard keyboard
 	dbus-run-session -- dconf write /org/onboard/auto-show/tablet-mode-detection-enabled false # shows keyboard only in tablet mode. I had to disable it to make it work

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -343,7 +343,8 @@ bashio::log.info "Setting keyboard layout and language to: $KEYBOARD_LAYOUT"
 setxkbmap -query  | sed 's/^/  /' #Log layout
 
 #### Launch virtual keyboard if needed
-KBD_PERSIST_FILE='/addon_config/af9e4035_haoskiosk/usr_custom_keyboad.ini'
+#KBD_PERSIST_FILE='/addon_config/af9e4035_haoskiosk/usr_custom_keyboad.ini'
+KBD_PERSIST_FILE='/config/usr_custom_keyboad.ini'
 
 if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	bashio::log.info "Configuring onscreen keyboard"
@@ -392,6 +393,9 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
 		dbus-run-session -- dconf write /org/onboard/auto-show/tablet-mode-detection-enabled false # shows keyboard only in tablet mode. I had to disable it to make it work
 		dbus-run-session -- dconf write /org/onboard/window/force-to-top true # always show in front
 	 	dbus-run-session -- gsettings set org.gnome.desktop.interface toolkit-accessibility true # disable gnome assessibility popup
+
+		#testing
+   		dconf dump / > $"KBD_PERSIST_FILE"
 	fi
 
 	### Launch keyboard

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -355,7 +355,7 @@ setxkbmap -query  | sed 's/^/  /' #Log layout
 if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	bashio::log.info "Configuring onscreen keyboard"
 
-	if [ "$PERSIST_ONSCREEN_KEYBOARD_CONFIG" = true ]; then
+	if [ "$PERSIST_ONSCREEN_KEYBOARD_CONFIG" = false ]; then
  		rm -f "$KBD_PERSIST_FILE"
 	fi
 

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -64,8 +64,8 @@ cleanup() {
 	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
     exit "$exit_code"
 }
-trap cleanup INT TERM EXIT
-#trap cleanup HUP INT QUIT ABRT TERM EXIT
+trap cleanup HUP INT QUIT ABRT TERM EXIT
+#trap cleanup INT TERM EXIT
 
 
 ################################################################################
@@ -355,7 +355,11 @@ setxkbmap -query  | sed 's/^/  /' #Log layout
 if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	bashio::log.info "Configuring onscreen keyboard"
 
- 	if [ "$PERSIST_ONSCREEN_KEYBOARD_CONFIG" = true ] && [ -f "$KBD_PERSIST_FILE" ]; then
+	if [ "$PERSIST_ONSCREEN_KEYBOARD_CONFIG" = false ]
+  		rm -f "$KBD_PERSIST_FILE"
+ 	fi
+
+ 	if [ -f "$KBD_PERSIST_FILE" ]; then
   		bashio::log.info "Restoring onscreen keyboard setup"
 
  		### Load all non-default settings from file and apply them

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -67,8 +67,8 @@ cleanup() {
 	if [ "$LUAKIT_PID" -ne "$exit_code" ]
     	[ -n "$(jobs -p)" ] && kill "$(jobs -p)"
     	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
-	    exit "$exit_code"
-    fi
+    exit "$exit_code"
+	fi
 }
 trap cleanup INT TERM EXIT
 

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -388,12 +388,12 @@ if [ "$USE_VIRTUAL_KEYBOARD" = true ]; then
 		dbus-run-session -- dconf write /org/onboard/window/landscape/height $(("$SCRN_HEIGHT"/2)) # set default height
 		dbus-run-session -- dconf write /org/onboard/window/landscape/width  "$SCRN_WIDTH" # set default width
 		dbus-run-session -- dconf write /org/onboard/window/landscape/x  0 # set default x coordinate
-		dbus-run-session -- dconf write /org/onboard/window/landscape/y  $(("$SCRN_WIDTH"/2-1)) # set default y coordinate
+		dbus-run-session -- dconf write /org/onboard/window/landscape/y  $(("$SCRN_HEIGHT"/2-1)) # set default y coordinate
   	else
 		dbus-run-session -- dconf write /org/onboard/window/portrait/height $(("$SCRN_HEIGHT"/4)) # set default height
 		dbus-run-session -- dconf write /org/onboard/window/portrait/width  "$SCRN_WIDTH" # set default width
 		dbus-run-session -- dconf write /org/onboard/window/portrait/x  0 # set default x coordinate
-		dbus-run-session -- dconf write /org/onboard/window/portrait/y  $(("$SCRN_WIDTH"*3/4-1)) # set default y coordinate
+		dbus-run-session -- dconf write /org/onboard/window/portrait/y  $(("$SCRN_HEIGHT"*3/4-1)) # set default y coordinate
   		bashio::log.info "Screen is in Portrait mode"
     fi
 

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -386,12 +386,12 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
 			dbus-run-session -- dconf write /org/onboard/window/landscape/height $(("$SCRN_HEIGHT"/2))
 			dbus-run-session -- dconf write /org/onboard/window/landscape/width "$SCRN_WIDTH"
 			dbus-run-session -- dconf write /org/onboard/window/landscape/x 0
-			dbus-run-session -- dconf write /org/onboard/window/landscape/y $(("$SCRN_HEIGHT"/2-1))
+			dbus-run-session -- dconf write /org/onboard/window/landscape/y $(("$SCRN_HEIGHT"/2))
 	  	else
 			dbus-run-session -- dconf write /org/onboard/window/portrait/height $(("$SCRN_HEIGHT"/4))
 			dbus-run-session -- dconf write /org/onboard/window/portrait/width "$SCRN_WIDTH"
 			dbus-run-session -- dconf write /org/onboard/window/portrait/x 0
-			dbus-run-session -- dconf write /org/onboard/window/portrait/y $(("$SCRN_HEIGHT"*3/4-1))
+			dbus-run-session -- dconf write /org/onboard/window/portrait/y $(("$SCRN_HEIGHT"*3/4))
 	    fi
 
 	  	### Enable keyboard to auto appear when inputting text

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -59,7 +59,7 @@ KBD_FILE_MUST_PERSIST=""
 KBD_PERSIST_FILE="/config/usr_custom_keyboad.ini"
 cleanup() {
     local exit_code=$?
-	[ -n "$KBD_FILE_MUST_PERSIST" ] && [ ! [ $(rm -f "$KBD_PERSIST_FILE) ] ] && [ $(dconf dump / > "$KBD_PERSIST_FILE") ]
+	[ -n "$KBD_FILE_MUST_PERSIST" ] && dconf dump / > "$KBD_PERSIST_FILE"
 	[ -n "$(jobs -p)" ] && kill "$(jobs -p)"
 	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
     exit "$exit_code"

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -343,17 +343,16 @@ bashio::log.info "Setting keyboard layout and language to: $KEYBOARD_LAYOUT"
 setxkbmap -query  | sed 's/^/  /' #Log layout
 
 #### Launch virtual keyboard if needed
+KBD_PERSIST_FILE='/data/usr_custom_keybd.ini'
+
 if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	bashio::log.info "Configuring onscreen keyboard"
 
-	KBD_PERSIST_FILE='/usr_custom_keybd.cfg/'
 	if [[ -f "$KBD_PERSIST_FILE" ]]; then
-  		bashio::log.info "Restoring previous onscreen keyboard setup"
+  		bashio::log.info "Restoring onscreen keyboard setup"
 
  		# figure out how to load all CHANGED settings from file and apply them
-   		# Doing a "dconf dump /" at the HAOS-kiosk container terminal will show you everything you have set.
-	 	# Doing "gsettings list-recursively org.onboard | more" lists everything that is settabl
-	
+   		dconf load / < $"KBD_PERSIST_FILE"	
  	else
   		bashio::log.info "Using default onscreen keyboard setup"
 
@@ -383,20 +382,20 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
 			dbus-run-session -- dconf write /org/onboard/window/portrait/x 0
 			dbus-run-session -- dconf write /org/onboard/window/portrait/y $(("$SCRN_HEIGHT"*3/4-1))
 	    fi
+
+	  	### Enable keyboard to auto appear when inputting text
+	    ### dbus-run-session -- dconf write /org/onboard/auto-show true # enable auto show
+		#dbus-run-session -- dconf write /org/onboard/start-minimized true # hide keyboard at startup
+		dbus-run-session -- dconf write /org/onboard/xembed-onboard false # do not start in XEmbed mode 
+		dbus-run-session -- dconf write /org/onboard/auto-show/enabled true # enable auto show
+		dbus-run-session -- dconf write /org/onboard/auto-show/tablet-mode-detection-enabled false # shows keyboard only in tablet mode. I had to disable it to make it work
+		dbus-run-session -- dconf write /org/onboard/window/force-to-top true # always show in front
+	 	dbus-run-session -- gsettings set org.gnome.desktop.interface toolkit-accessibility true # disable gnome assessibility popup
+	  	#dbus-run-session -- gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true
+	    #dbus-run-session -- gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false
+		#dbus-send --type=method_call --print-reply --dest=org.onboard.Onboard /org/onboard/Onboard/Keyboard org.onboard.Onboard.Keyboard.Hide
+	
 	fi
-
- 	### Enable keyboard to auto appear when inputting text
-    ### dbus-run-session -- dconf write /org/onboard/auto-show true # enable auto show
-	#dbus-run-session -- dconf write /org/onboard/start-minimized true # hide keyboard at startup
-	dbus-run-session -- dconf write /org/onboard/xembed-onboard false # do not start in XEmbed mode 
-	dbus-run-session -- dconf write /org/onboard/auto-show/enabled true # enable auto show
-	dbus-run-session -- dconf write /org/onboard/auto-show/tablet-mode-detection-enabled false # shows keyboard only in tablet mode. I had to disable it to make it work
-	dbus-run-session -- dconf write /org/onboard/window/force-to-top true # always show in front
- 	dbus-run-session -- gsettings set org.gnome.desktop.interface toolkit-accessibility true # disable gnome assessibility popup
-  	#dbus-run-session -- gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true
-    #dbus-run-session -- gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false
-	#dbus-send --type=method_call --print-reply --dest=org.onboard.Onboard /org/onboard/Onboard/Keyboard org.onboard.Onboard.Keyboard.Hide
-
 
 	### Launch keyboard
  	bashio::log.info "Starting onscreen keyboard"
@@ -431,9 +430,8 @@ fi
 #### Persist virtual keyboard settings if needed
 if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	if [ "$PERSIST_ONSCREEN_KEYBOARD_CONFIG" = true ]; then
- 		bashio::log.info "Saving onscreen keyboard setup"
+ 		bashio::log.info "Backing up onscreen keyboard setup"
  		# figure out how to save all CHANGED settings from file and apply them
-   		# Doing a "dconf dump /" at the HAOS-kiosk container terminal will show you everything you have set.
-	 	# Doing "gsettings list-recursively org.onboard | more" lists everything that is settabl
+   		dconf dump / > $"KBD_PERSIST_FILE"
 	fi
 fi

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -65,7 +65,7 @@ cleanup() {
 	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
     exit "$exit_code"
 }
-trap cleanup INT EXIT
+trap cleanup INT TERM EXIT
 unset ONSCREEN_KEYBOARD
 unset PERSIST_ONSCREEN_KEYBOARD_CONFIG
 

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -399,6 +399,7 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
 		dbus-run-session -- dconf write /org/onboard/auto-show/tablet-mode-detection-enabled false # shows keyboard only in tablet mode. I had to disable it to make it work
 		dbus-run-session -- dconf write /org/onboard/window/force-to-top true # always show in front
 	 	dbus-run-session -- gsettings set org.gnome.desktop.interface toolkit-accessibility true # disable gnome assessibility popup
+   		dbus-send --type=method_call --print-reply --dest=org.onboard.Onboard /org/onboard/Onboard/Keyboard org.onboard.Onboard.Keyboard.Hide # default hide keyboard
 	fi
 
 	### Launch keyboard

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -388,12 +388,12 @@ if [ "$USE_VIRTUAL_KEYBOARD" = true ]; then
 		dbus-run-session -- dconf write /org/onboard/window/landscape/height $(("$SCRN_HEIGHT"/2)) # set default height
 		dbus-run-session -- dconf write /org/onboard/window/landscape/width  "$SCRN_WIDTH" # set default width
 		dbus-run-session -- dconf write /org/onboard/window/landscape/x  0 # set default x coordinate
-		dbus-run-session -- dconf write /org/onboard/window/landscape/y  $(("$SCRN_WIDTH"/2)) # set default y coordinate
+		dbus-run-session -- dconf write /org/onboard/window/landscape/y  $(("$SCRN_WIDTH"/2-1)) # set default y coordinate
   	else
 		dbus-run-session -- dconf write /org/onboard/window/portrait/height $(("$SCRN_HEIGHT"/4)) # set default height
 		dbus-run-session -- dconf write /org/onboard/window/portrait/width  "$SCRN_WIDTH" # set default width
 		dbus-run-session -- dconf write /org/onboard/window/portrait/x  0 # set default x coordinate
-		dbus-run-session -- dconf write /org/onboard/window/portrait/y  $(("$SCRN_WIDTH"*3/4)) # set default y coordinate
+		dbus-run-session -- dconf write /org/onboard/window/portrait/y  $(("$SCRN_WIDTH"*3/4-1)) # set default y coordinate
   		bashio::log.info "Screen is in Portrait mode"
     fi
 

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -405,6 +405,16 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	dbus-run-session onboard &
 fi
 
+#### Persist virtual keyboard settings if needed
+if [ "$ONSCREEN_KEYBOARD" = true ]; then
+	if [ "$PERSIST_ONSCREEN_KEYBOARD_CONFIG" = true ]; then
+ 		bashio::log.info "Backing up onscreen keyboard setup"
+   
+ 		# Save only non-default settings
+   		dconf dump / > $"KBD_PERSIST_FILE"
+	fi
+fi
+
 #### Poll to send <Control-r> when screen unblanks to force reload of luakit page if BROWSWER_REFRESH set
 if [ "$BROWSER_REFRESH" -ne 0 ]; then
     (

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -385,15 +385,15 @@ if [ "$USE_VIRTUAL_KEYBOARD" = true ]; then
 	bashio::log.info "Screen Resolution is $SCRN_WIDTH x $SCRN_HEIGHT"
  	if [ $SCRN_WIDTH -ge $SCRN_HEIGHT ] ; then
   		bashio::log.info "Screen is in Landscape mode"
-		dbus-run-session -- dconf write /org/onboard/window/landscape/height ("$SCRN_HEIGHT"/2) # set default height
+		dbus-run-session -- dconf write /org/onboard/window/landscape/height $(("$SCRN_HEIGHT"/2)) # set default height
 		dbus-run-session -- dconf write /org/onboard/window/landscape/width  "$SCRN_WIDTH" # set default width
 		dbus-run-session -- dconf write /org/onboard/window/landscape/x  0 # set default x coordinate
-		dbus-run-session -- dconf write /org/onboard/window/landscape/y  ("$SCRN_WIDTH"/2) # set default y coordinate
+		dbus-run-session -- dconf write /org/onboard/window/landscape/y  $(("$SCRN_WIDTH"/2)) # set default y coordinate
   	else
-		dbus-run-session -- dconf write /org/onboard/window/portrait/height ("$SCRN_HEIGHT"/4) # set default height
+		dbus-run-session -- dconf write /org/onboard/window/portrait/height $(("$SCRN_HEIGHT"/4)) # set default height
 		dbus-run-session -- dconf write /org/onboard/window/portrait/width  "$SCRN_WIDTH" # set default width
 		dbus-run-session -- dconf write /org/onboard/window/portrait/x  0 # set default x coordinate
-		dbus-run-session -- dconf write /org/onboard/window/portrait/y  ("$SCRN_WIDTH"*3/4) # set default y coordinate
+		dbus-run-session -- dconf write /org/onboard/window/portrait/y  $(("$SCRN_WIDTH"*3/4)) # set default y coordinate
   		bashio::log.info "Screen is in Portrait mode"
     fi
 

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -58,6 +58,7 @@ TTY0_DELETED="" #Need to set to empty string since runs with nounset=on (like se
 KBD_PERSIST_FILE="/config/usr_custom_keyboad.ini"
 cleanup() {
     local exit_code=$?
+	# Always save keyboard info
 	dconf dump / > "$KBD_PERSIST_FILE"
 	[ -n "$(jobs -p)" ] && kill "$(jobs -p)"
 	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -348,13 +348,16 @@ KBD_PERSIST_FILE='/data/usr_custom_keybd.ini'
 if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	bashio::log.info "Configuring onscreen keyboard"
 
-	if [[ -f "$KBD_PERSIST_FILE" ]]; then
+	if [ "$PERSIST_ONSCREEN_KEYBOARD_CONFIG" = true ] && [ -f "$KBD_PERSIST_FILE" ]; then
   		bashio::log.info "Restoring onscreen keyboard setup"
 
- 		# figure out how to load all CHANGED settings from file and apply them
+ 		### Load all non-default settings from file and apply them
    		dconf load / < $"KBD_PERSIST_FILE"	
  	else
   		bashio::log.info "Using default onscreen keyboard setup"
+
+  		### Delete settings file if it exists 
+ 		rm -f $"KBD_PERSIST_FILE"
 
  		### Set default layout, theme and colors
 		dbus-run-session -- dconf write /org/onboard/layout \''/usr/share/onboard/layouts/Small.onboard'\'
@@ -431,7 +434,8 @@ fi
 if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	if [ "$PERSIST_ONSCREEN_KEYBOARD_CONFIG" = true ]; then
  		bashio::log.info "Backing up onscreen keyboard setup"
- 		# figure out how to save all CHANGED settings from file and apply them
+   
+ 		# Save only non-default settings
    		dconf dump / > $"KBD_PERSIST_FILE"
 	fi
 fi

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -406,7 +406,7 @@ if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	 	dbus-run-session -- gsettings set org.gnome.desktop.interface toolkit-accessibility true # disable gnome assessibility popup
 
    		### Start Keyboard minimized (should auto show when clicking on text input field)
-	 	dbus-run-session -- dconf write /org/onboard/start-minimized true
+	 	### dbus-run-session -- dconf write /org/onboard/start-minimized true # keyboard is hidden, but never comes up automatically
 
 		### Save a copy of modifie settings once in case system aborts before cleanup runs
    		dconf dump / > "$KBD_PERSIST_FILE"

--- a/haoskiosk/run.sh
+++ b/haoskiosk/run.sh
@@ -64,8 +64,8 @@ cleanup() {
 	[ -n "$TTY0_DELETED" ] && mknod -m 620 /dev/tty0 c 4 0
     exit "$exit_code"
 }
-trap cleanup INT TERM EXIT
-#trap cleanup HUP INT QUIT ABRT TERM EXIT
+trap cleanup HUP INT QUIT ABRT TERM EXIT
+#trap cleanup INT TERM EXIT
 
 
 ################################################################################
@@ -355,9 +355,9 @@ setxkbmap -query  | sed 's/^/  /' #Log layout
 if [ "$ONSCREEN_KEYBOARD" = true ]; then
 	bashio::log.info "Configuring onscreen keyboard"
 
-	if [ "$PERSIST_ONSCREEN_KEYBOARD_CONFIG" = false ]
-  		rm -f "$KBD_PERSIST_FILE"
- 	fi
+	#if [ "$PERSIST_ONSCREEN_KEYBOARD_CONFIG" = false ]
+  	#	rm -f "$KBD_PERSIST_FILE"
+ 	#fi
 
  	if [ -f "$KBD_PERSIST_FILE" ]; then
   		bashio::log.info "Restoring onscreen keyboard setup"

--- a/haoskiosk/translations/en.yaml
+++ b/haoskiosk/translations/en.yaml
@@ -93,7 +93,6 @@ configuration:
   persist_onscreen_keyboard_config:
     name: "Persist Onscreen Keyboard Config"
     description: |
-      If 'true', then save user customizations when the Add-on ends.
       If 'true', then restore user customizations when the Add-on starts.
       If 'false', then default settings when the Add-on starts.
       

--- a/haoskiosk/translations/en.yaml
+++ b/haoskiosk/translations/en.yaml
@@ -85,3 +85,15 @@ configuration:
     description: |
       Launch X and Openbox but not Luakit browser.
       Manually access using: sudo docker -exec -it addon_haoskiosk bash
+  onscreen_keyboard:
+    name: "Onscreen Keyboard"
+    description: |
+      If 'true', then launch a customisable onscreen keyboard whenever
+      text needs to be entered.
+  persist_onscreen_keyboard_config:
+    name: "Persist Onscreen Keyboard Config"
+    description: |
+      If 'true', then save user customizations when the Add-on ends.
+      If 'true', then restore user customizations when the Add-on starts.
+      If 'false', then default settings when the Add-on starts.
+      


### PR DESCRIPTION
Hi @puterboy and @taucher4000

I see both of you are still working on touchscreens, and need your help.

My use case is HAOS-kiosk running on 7" Pi Touch Display 2, as a standalone device with no keyboard (and wont ever have one).

With your guys help, we seem to have gotten all issues around touchscreens working, except that I would dearly love to have a virtual on screen keyboard for the rare instances when user wants to enter text, or an admin needs to.

Attached is my PR for changes I've made to have SVKBD run - but alas, it does seem to work for me. (Please note my test device is in Switzerland, and I'm in South Africa, so I can only remote in and never SEE the device with my own eyes - I rely on users to tell me it's working or not).

I have also tried matchbox-keyboard, and several others, but all to no avail. Perhaps you guys cam help?

Another possibility is that LUAKIT (of which I know ZERO) has a virtual keyboard "plugin" (cant remember the correct work - googling for a week hasn't helped me) much like chrome has a  virtual keyboard plugin and / or Accessibility Keyboard settings.

I'm happy to help with tests you may suggest, but after a week I've gotten no further.

P.S. SVKBD is for X11, WVKBD is for Wayland - LOTS of people say to use WVKBD and that it works - but ultimately they are all running PiOs (which runs Wayland), and none are using HAOS (which in HAOS-kiosk uses X11).

Please help!