### PR TITLE
set browser_mod-browser-id in the localStorage to a static value

### DIFF
--- a/haoskiosk/userconf.lua
+++ b/haoskiosk/userconf.lua
@@ -209,6 +209,9 @@ webview.add_signal("init", function(view)
 
             local js_settings = string.format([[
                 try {
+                    // Set browser_mod browser ID to "haos_kiosk"
+                    localStorage.setItem('browser_mod-browser-id', 'haos_kiosk');
+
                     // Set sidebar visibility
 		    const sidebar = '%s';
                     const currentSidebar = localStorage.getItem('dockedSidebar') || '';


### PR DESCRIPTION
## Summary  
This PR improves compatibility with the **browser_mod** integration when using HAOS-Kiosk.  

## Details  
By default, HAOS-Kiosk runs in a Docker container and generates a new browser ID each time the add-on restarts. This makes it difficult to build automations that rely on browser_mod.  

To resolve this, the `haoskiosk/userconf.lua` file has been updated to set `browser_mod-browser-id` in `localStorage` to a fixed value (`haos_kiosk`). This ensures that HAOS-Kiosk is always registered with the same browser ID.  

## Testing  
This change has been successfully tested with the latest **browser_mod** version (`2.5.0`).  
- Restarted HAOS-Kiosk multiple times to confirm the browser ID remains consistent.  
- Verified that automations depending on a fixed browser ID work as expected.

