### PR TITLE
fix(docker): default BUILD_FROM for Supervisor BuildKit builds

### DIFF
--- a/haoskiosk/Dockerfile
+++ b/haoskiosk/Dockerfile
@@ -6,7 +6,7 @@
 # Date: April 2026
 ################################################################################
 
-ARG BUILD_FROM
+ARG BUILD_FROM=ghcr.io/home-assistant/base:latest
 FROM $BUILD_FROM
 
 ARG BUILD_VERSION


### PR DESCRIPTION
Supervisor may no longer pass BUILD_FROM on every build path after the
Home Assistant builder migration to Docker BuildKit. An empty ARG
produced 'base name (\) should not be blank' and failed the
add-on image build.

Set the official multi-arch default from the HA app documentation:
ghcr.io/home-assistant/base:latest. Supervisor can still override this
when it supplies BUILD_FROM explicitly.

Made-with: Cursor