### PR TITLE
⛑️ Fix for supervisor `2026.04.0` changes

### DIFF
--- a/haoskiosk/Dockerfile
+++ b/haoskiosk/Dockerfile
@@ -6,8 +6,7 @@
 # Date: April 2026
 ################################################################################
 
-ARG BUILD_FROM
-FROM $BUILD_FROM
+FROM ghcr.io/home-assistant/base:latest
 
 ARG BUILD_VERSION
 ENV ADDON_VERSION=${BUILD_VERSION}


### PR DESCRIPTION
In the latest Home Assistant Supervisor update, the `$BUILD_FROM` env arg is no longer populated, making this image impossible to build or run.

Following the [new best practices ](https://developers.home-assistant.io/docs/apps/configuration/#:~:text=Build%20args%E2%80%8B&text=App%20version%20(read%20from%20config,yaml%20).&text=Holds%20the%20current%20build%20arch%20inside.&text=note-,Since%20Supervisor%202026.04.,recommended%20for%20better%20build%20stability.)from HA on this topic, `$BUILD_FROM` has been removed and replaced with an explicit container image link.

This allows the image to build and run successfully. Tested on my instance for stability.