### PR TITLE
Add Noto fonts for CJK and emoji rendering

### DIFF
--- a/haoskiosk/Dockerfile
+++ b/haoskiosk/Dockerfile
@@ -43,6 +43,9 @@ RUN apk update && apk add --no-cache \
      onboard \
      unclutter-xfixes \
      ttf-dejavu \
+     font-noto \
+     font-noto-cjk \
+     font-noto-emoji \
 ### Linux utils
      bash \
      util-linux \


### PR DESCRIPTION
Thank you for this excellent add-on.

I am currently using it with a [Waveshare 7-inch display](https://www.waveshare.com/wiki/7-DSI-TOUCH-C), and it works almost perfectly.

However, I noticed that some non-Latin characters are not rendered properly. In my case, Japanese text is displayed as tofu boxes because the container does not include suitable fonts.

This PR adds Noto fonts to improve multilingual text rendering in Home Assistant dashboards. In particular, it improves rendering for CJK text, such as Chinese, Japanese, and Korean, as well as emoji.

## Before this PR

<img width="185" height="97" alt="Japanese text rendered as tofu boxes before this PR" src="https://github.com/user-attachments/assets/97749ae3-c4d6-4eb5-9cff-33b43dbbf6d8" />

## After this PR

<img width="186" height="105" alt="Japanese text rendered correctly after this PR" src="https://github.com/user-attachments/assets/b9a1a386-7309-4ec8-a899-50752d8b59e1" />